### PR TITLE
Replace formset.fields with formset.cleaned_data

### DIFF
--- a/lowfat/views.py
+++ b/lowfat/views.py
@@ -244,7 +244,7 @@ def fund_form(request):
         if formset.is_valid():
             fund = formset.save()
             messages.success(request, 'Funding request saved on our database.')
-            if formset.fields["send_email_field"]:
+            if formset.cleaned_data["send_email_field"]:
                 new_fund_notification(fund)
 
             # Default value for budget_approved is budget_total.
@@ -318,7 +318,7 @@ def fund_review(request, fund_id):
 
         if formset.is_valid():
             fund = formset.save()
-            if formset.fields["send_email_field"]:
+            if formset.cleaned_data["send_email_field"]:
                 fund_review_notification(
                     formset.cleaned_data['email'],
                     request.user,
@@ -408,7 +408,7 @@ def expense_form(request):
     if formset.is_valid():
         expense = formset.save()
         messages.success(request, 'Expense saved on our database.')
-        if formset.fields["send_email_field"]:
+        if formset.cleaned_data["send_email_field"]:
             new_expense_notification(expense)
         return HttpResponseRedirect(
             reverse('expense_detail', args=[expense.id,])
@@ -467,7 +467,7 @@ def expense_review(request, expense_id):
 
         if formset.is_valid():
             expense = formset.save()
-            if formset.fields["send_email_field"]:
+            if formset.cleaned_data["send_email_field"]:
                 expense_review_notification(
                     formset.cleaned_data['email'],
                     request.user,
@@ -535,7 +535,7 @@ def blog_form(request):
         blog.save()
 
         messages.success(request, 'Blog draft saved on our database.')
-        if formset.fields["send_email_field"]:
+        if formset.cleaned_data["send_email_field"]:
             if blog.fund:
                 new_blog_notification(blog)
         return HttpResponseRedirect(
@@ -591,7 +591,7 @@ def blog_review(request, blog_id):
 
         if formset.is_valid():
             blog = formset.save()
-            if formset.fields["send_email_field"]:
+            if formset.cleaned_data["send_email_field"]:
                 blog_review_notification(
                     formset.cleaned_data['email'],
                     request.user,


### PR DESCRIPTION
Related with #295 .

~~~
>>> from lowfat.forms import BlogReviewForm
>>> from lowfat.models import Blog
>>> blog = Blog.objects.all()[0]
>>> formset = BlogReviewForm({"draft_url": "foo"}, instance=blog)
>>> formset.fields
OrderedDict([('draft_url', <django.forms.fields.CharField object at 0x7f62d43cf978>), ('final', <django.forms.fields.BooleanField object at 0x7f62d43cf4a8>), ('status', <django.forms.fields.TypedChoiceField object at 0x7f62d42ec2b0>), ('reviewer', <django.forms.models.ModelChoiceField object at 0x7f62d42ec400>), ('notes_from_admin', <django.forms.fields.CharField object at 0x7f62d42ec278>), ('published_url', <django.forms.fields.CharField object at 0x7f62d42ec668>), ('tweet_url', <django.forms.fields.CharField object at 0x7f62d42ec7b8>), ('send_email_field', <django.forms.fields.BooleanField object at 0x7f62d42ec860>), ('email', <django.forms.fields.CharField object at 0x7f62d42ec8d0>)])
>>> formset.is_valid()
False
>>> formset.cleaned_data
{'draft_url': 'foo', 'final': False, 'reviewer': None, 'notes_from_admin': '', 'published_url': '', 'tweet_url': '', 'send_email_field': False, 'email': ''}
~~~

Because of it, `formset.fields["send_email_field"]` will be always `True`.