### PR TITLE
Fix bug with email notification

### DIFF
--- a/lowfat/forms.py
+++ b/lowfat/forms.py
@@ -25,11 +25,11 @@ TODAY_YEAR = datetime.now().year
 SELECT_DATE_WIDGE_YEARS = [TODAY_YEAR + delta for delta in range(-3, 4)]
 
 class GarlicForm(ModelForm):
-    send_email_field = BooleanField(
+    not_send_email_field = BooleanField(
         widget=CheckboxInput,
         required=False,
-        initial=True,
-        label="Send email notification for this update to claimant?"
+        initial=False,
+        label="Suppress email notification for this update to claimant?"
     )
 
     def __init__(self, *args, **kwargs):
@@ -296,7 +296,7 @@ class FundForm(GarlicForm):
                 HTML('<h2>Publicity</h2>'),
                 'can_be_advertise_before',
                 'can_be_advertise_after',
-                'send_email_field' if self.is_staff else None,
+                'not_send_email_field' if self.is_staff else None,
                 ButtonHolder(
                     Submit('submit', '{{ title }}')
                 )
@@ -350,7 +350,7 @@ class FundReviewForm(GarlicForm):
                 ),
                 "notes_from_admin",
                 "email",
-                'send_email_field' if self.is_staff else None,
+                'not_send_email_field' if self.is_staff else None,
             )
         )
 
@@ -399,7 +399,7 @@ class FundImportForm(Form):
 </ul>
 <p class="text-danger">You will not have access to debug information!</p>"""),
                 'csv',
-                'send_email_field' if self.is_staff else None,
+                'not_send_email_field' if self.is_staff else None,
                 ButtonHolder(
                     Submit('submit', '{{ title }}')
                 )
@@ -472,7 +472,7 @@ class ExpenseForm(GarlicForm):
                 'recipient_group',
                 HTML("<p>You need to provide a reason for submit the recipient claim. An common reasons is \"because the recipient was of of the speakers on that workshop\".</p>"),
                 'recipient_connection',
-                'send_email_field' if self.is_staff else None,
+                'not_send_email_field' if self.is_staff else None,
                 ButtonHolder(
                     Submit('submit', '{{ title }}')
                 )
@@ -535,7 +535,7 @@ class ExpenseReviewForm(GarlicForm):
                 'grant_used',
                 'notes_from_admin',
                 'email',
-                'send_email_field' if self.is_staff else None,
+                'not_send_email_field' if self.is_staff else None,
                 ButtonHolder(
                     Submit('submit', 'Update')
                 )
@@ -596,7 +596,7 @@ class BlogForm(GarlicForm):
                 HTML('<p>To apply for expenses for eligible events, please fill in this form at least one month before the start date of the event you wish to attend or organise.</p><h2>Requester details</h2>'),
                 'final',
                 'notes_from_author',
-                'send_email_field' if self.is_staff else None,
+                'not_send_email_field' if self.is_staff else None,
                 ButtonHolder(
                     Submit('submit', '{{ title }}')
                 )
@@ -642,7 +642,7 @@ class BlogReviewForm(GarlicForm):
                 'published_url',
                 'tweet_url',
                 'email',
-                'send_email_field' if self.is_staff else None,
+                'not_send_email_field' if self.is_staff else None,
                 ButtonHolder(
                     Submit('submit', 'Update')
                 )

--- a/lowfat/views.py
+++ b/lowfat/views.py
@@ -237,7 +237,7 @@ def fund_form(request):
         if formset.is_valid():
             fund = formset.save()
             messages.success(request, 'Funding request saved on our database.')
-            if formset.cleaned_data["send_email_field"]:
+            if not formset.cleaned_data["not_send_email_field"]:
                 new_fund_notification(fund)
 
             # Default value for budget_approved is budget_total.
@@ -311,7 +311,7 @@ def fund_review(request, fund_id):
 
         if formset.is_valid():
             fund = formset.save()
-            if formset.cleaned_data["send_email_field"]:
+            if not formset.cleaned_data["not_send_email_field"]:
                 fund_review_notification(
                     formset.cleaned_data['email'],
                     request.user,
@@ -401,7 +401,7 @@ def expense_form(request):
     if formset.is_valid():
         expense = formset.save()
         messages.success(request, 'Expense saved on our database.')
-        if formset.cleaned_data["send_email_field"]:
+        if not formset.cleaned_data["not_send_email_field"]:
             new_expense_notification(expense)
         return HttpResponseRedirect(
             reverse('expense_detail', args=[expense.id,])
@@ -460,7 +460,7 @@ def expense_review(request, expense_id):
 
         if formset.is_valid():
             expense = formset.save()
-            if formset.cleaned_data["send_email_field"]:
+            if not formset.cleaned_data["not_send_email_field"]:
                 expense_review_notification(
                     formset.cleaned_data['email'],
                     request.user,
@@ -540,7 +540,7 @@ def blog_form(request):
         blog.save()
 
         messages.success(request, 'Blog draft saved on our database.')
-        if formset.cleaned_data["send_email_field"]:
+        if not formset.cleaned_data["not_send_email_field"]:
             new_blog_notification(blog)
         return HttpResponseRedirect(
             reverse('blog_detail', args=[blog.id,])
@@ -596,7 +596,7 @@ def blog_review(request, blog_id):
 
         if formset.is_valid():
             blog = formset.save()
-            if formset.cleaned_data["send_email_field"]:
+            if not formset.cleaned_data["not_send_email_field"]:
                 blog_review_notification(
                     formset.cleaned_data['email'],
                     request.user,


### PR DESCRIPTION
If checkbox is checked the web browser will send

~~~
{
    ...,
    "send_email_field": "on",
    ...
}
~~~

but otherwise it will not include "send_email_field"
on the request what make hard to know if we should
or not send the email.

This pull request change the question
to make easy to know when the email should be send.

# Alternative solution

Replace

~~~
if formset.cleaned_data["send_email_field"]:
~~~

with

~~~
if not "send_email_field" in request.POST or request.POST["send_email_field"]:
~~~

This solution would make hard to maintain lowFAT.