### PR TITLE
Add option to email staffs when claimant is emailed

### DIFF
--- a/lowfat/forms.py
+++ b/lowfat/forms.py
@@ -31,6 +31,12 @@ class GarlicForm(ModelForm):
         initial=False,
         label="Suppress email notification for this update to claimant?"
     )
+    not_copy_email_field = BooleanField(
+        widget=CheckboxInput,
+        required=False,
+        initial=True,
+        label="Suppress copy of email to staff?"
+    )
 
     def __init__(self, *args, **kwargs):
         # Add staff option to not send email notification
@@ -352,6 +358,7 @@ class FundReviewForm(GarlicForm):
                 "notes_from_admin",
                 "email",
                 'not_send_email_field' if self.is_staff else None,
+                'not_copy_email_field' if self.is_staff else None,
             )
         )
 
@@ -537,6 +544,7 @@ class ExpenseReviewForm(GarlicForm):
                 'notes_from_admin',
                 'email',
                 'not_send_email_field' if self.is_staff else None,
+                'not_copy_email_field' if self.is_staff else None,
                 ButtonHolder(
                     Submit('submit', 'Update')
                 )
@@ -645,6 +653,7 @@ class BlogReviewForm(GarlicForm):
                 'tweet_url',
                 'email',
                 'not_send_email_field' if self.is_staff else None,
+                'not_copy_email_field' if self.is_staff else None,
                 ButtonHolder(
                     Submit('submit', 'Update')
                 )

--- a/lowfat/views.py
+++ b/lowfat/views.py
@@ -366,7 +366,8 @@ def fund_review(request, fund_id):
                     formset.cleaned_data['email'],
                     request.user,
                     old_fund,
-                    fund
+                    fund,
+                    not formset.cleaned_data['not_copy_email_field']
                 )
             return HttpResponseRedirect(
                 reverse('fund_detail', args=[fund.id,])
@@ -515,7 +516,8 @@ def expense_review(request, expense_id):
                     formset.cleaned_data['email'],
                     request.user,
                     old_expense,
-                    expense
+                    expense,
+                    not formset.cleaned_data['not_copy_email_field']
                 )
             return HttpResponseRedirect(
                 reverse('expense_detail', args=[expense.id,])
@@ -651,7 +653,8 @@ def blog_review(request, blog_id):
                     formset.cleaned_data['email'],
                     request.user,
                     old_blog,
-                    blog
+                    blog,
+                    not formset.cleaned_data['not_copy_email_field']
                 )
             return HttpResponseRedirect(
                 reverse('blog_detail', args=[blog.id,])


### PR DESCRIPTION
Related with #347.

@shoaibsufi I only added the option to the review forms because for new submission staffs received a email asking to process the request. Let me know if this is OK.