### PR TITLE
Fix BokehDeprecationWarning

### DIFF
--- a/lowfat/templates/lowfat/report.html
+++ b/lowfat/templates/lowfat/report.html
@@ -2,16 +2,16 @@
 
 {% block extra_css %}
 <link 
-    href="http://cdn.pydata.org/bokeh/release/bokeh-0.12.0.min.css"
+    href="http://cdn.pydata.org/bokeh/release/bokeh-0.12.6.min.css"
     rel="stylesheet" type="text/css">
 <link
-    href="http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.0.min.css"
+    href="http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.6.min.css"
     rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block extra_js %}
-<script src="http://cdn.pydata.org/bokeh/release/bokeh-0.12.0.min.js"></script>
-<script src="http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.0.min.js"></script>
+<script src="http://cdn.pydata.org/bokeh/release/bokeh-0.12.6.min.js"></script>
+<script src="http://cdn.pydata.org/bokeh/release/bokeh-widgets-0.12.6.min.js"></script>
 {% endblock %}
 
 {% block content %}

--- a/lowfat/views.py
+++ b/lowfat/views.py
@@ -11,9 +11,9 @@ from django.http import HttpResponseRedirect, Http404
 from django.urls import reverse
 from django.shortcuts import render
 
-from bokeh.charts import Bar, Histogram
 from bokeh.embed import components
 from bokeh.resources import CDN
+from bkcharts import Bar, Histogram
 
 from .management.commands import loadoldfunds as loadoldfunds
 from .models import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 bokeh
+bkcharts
 django
 django-backup
 django-constance[database]


### PR DESCRIPTION
The bokeh.charts API has moved to a separate 'bkcharts' package.

Related to #354.