### PR TITLE
Add model CarpentryWorkshop

### DIFF
--- a/lowfat/models.py
+++ b/lowfat/models.py
@@ -877,6 +877,47 @@ class Blog(models.Model):
     def link_review(self):
         return reverse("blog_review", args=[self.id])
 
+class CarpentryWorkshop(models.Model):
+    """Provide the link to the blog post about the fund."""
+    class Meta:
+        app_label = 'lowfat'
+
+    # Form
+    amy_id = models.CharField(  # Workshop ID used at https://amy.software-carpentry.org/workshops/admin-dashboard/
+        primary_key=True
+    )
+    host = models.ManyToManyField(
+        'Claimant',
+        blank=True,
+        related_name="host"
+    )
+    instructor = models.ManyToManyField(
+        'Claimant',
+        blank=True,
+        related_name="instructor"
+    )
+    helper = models.ManyToManyField(
+        'Claimant',
+        blank=True,
+        related_name="helper"
+    )
+
+    # Information to pull from AMY
+    start_date = models.DateField(
+        null=True
+    )
+    end_date = models.DateField(
+        null=True
+    )
+    Website =  = models.CharField(
+        max_length=MAX_URL_LENGTH,
+        validators=[online_document],
+        null=True
+    )
+    attendance  = models.IntegerField(
+        null=True
+    )
+
 class GeneralSentMail(models.Model):
     """Emails sent with custom text."""
     class Meta:


### PR DESCRIPTION
@anenadic said that we need to able to cross reference Fellows with Carpentry hosts/instructions/helpers. The changes at `lowfat/models.py` on this pull request will enhance lowFAT to keep the record of this cross reference.

# Fields (manual input)

- Event ID **in AMY**
- Fellows that were hosts
- Fellows that were instructions
- Fellows that were helpers

# Fields (can be input querying AMY)

- Start date
- End date
- Webste
- Attendance

# TODO

- [ ] @anenadic to review the fields