### PR TITLE
Work around object has no attribute 'contribute_to_class'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 django<2.0
 django-constance[database]
 django-countries
-git+https://github.com/radiac/django-tagulous.git@feature/django-1_11#egg=django-tagulous #django-tagulous
+git+https://github.com/rgaiacs/django-tagulous.git@0.13.0#egg=django-tagulous #django-tagulous
 django-crispy-forms
 django-datetime-widget
 django-dbbackup>=3.2.0


### PR DESCRIPTION
https://github.com/radiac/django-tagulous/issues/14 mentions one workaround
that was never added to the source tree.
We swap the origin of django-tagulous until
https://github.com/radiac/django-tagulous/pull/45 is merged.