### PR TITLE
Use developement version of Pandas to pass tests in Travis CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ html2text
 markdown
 matplotlib
 numpy
-pandas
+git+https://github.com/pandas-dev/pandas.git@master#egg=panda
 pylint>=1.8.2
 pylint-django>=0.9.0
 pypdf2


### PR DESCRIPTION
When building pandas, Travis CI reports

```
  gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -Ipandas/_libs/src/klib -Ipandas/_libs/src -I/home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/numpy/core/include -I/opt/python/3.7-dev/include/python3.7m -c pandas/_libs/lib.c -o build/temp.linux-x86_64-3.7/pandas/_libs/lib.o -Wno-unused-function
  In file included from /home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/numpy/core/include/numpy/ndarraytypes.h:1821:0,
                   from /home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/numpy/core/include/numpy/ndarrayobject.h:18,
                   from /home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                   from pandas/_libs/lib.c:526:
  /home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
   #warning "Using deprecated NumPy API, disable it by " \
    ^
  In file included from pandas/_libs/src/compat_helper.h:14:0,
                   from pandas/_libs/lib.c:528:
  pandas/_libs/src/numpy_helper.h: In function ‘get_c_string’:
  pandas/_libs/src/numpy_helper.h:72:5: warning: return discards ‘const’ qualifier from pointer target type [enabled by default]
       return PyUnicode_AsUTF8(obj);
       ^
  pandas/_libs/lib.c: In function ‘__Pyx__ExceptionSave’:
  pandas/_libs/lib.c:99985:19: error: ‘PyThreadState’ has no member named ‘exc_type’
       *type = tstate->exc_type;
                     ^
  pandas/_libs/lib.c:99986:20: error: ‘PyThreadState’ has no member named ‘exc_value’
       *value = tstate->exc_value;
                      ^
  pandas/_libs/lib.c:99987:17: error: ‘PyThreadState’ has no member named ‘exc_traceback’
       *tb = tstate->exc_traceback;
                   ^
  pandas/_libs/lib.c: In function ‘__Pyx__ExceptionReset’:
  pandas/_libs/lib.c:99994:22: error: ‘PyThreadState’ has no member named ‘exc_type’
       tmp_type = tstate->exc_type;
                        ^
  pandas/_libs/lib.c:99995:23: error: ‘PyThreadState’ has no member named ‘exc_value’
       tmp_value = tstate->exc_value;
                         ^
  pandas/_libs/lib.c:99996:20: error: ‘PyThreadState’ has no member named ‘exc_traceback’
       tmp_tb = tstate->exc_traceback;
                      ^
  pandas/_libs/lib.c:99997:11: error: ‘PyThreadState’ has no member named ‘exc_type’
       tstate->exc_type = type;
             ^
  pandas/_libs/lib.c:99998:11: error: ‘PyThreadState’ has no member named ‘exc_value’
       tstate->exc_value = value;
             ^
  pandas/_libs/lib.c:99999:11: error: ‘PyThreadState’ has no member named ‘exc_traceback’
       tstate->exc_traceback = tb;
             ^
  pandas/_libs/lib.c: In function ‘__Pyx__GetException’:
  pandas/_libs/lib.c:100430:22: error: ‘PyThreadState’ has no member named ‘exc_type’
       tmp_type = tstate->exc_type;
                        ^
  pandas/_libs/lib.c:100431:23: error: ‘PyThreadState’ has no member named ‘exc_value’
       tmp_value = tstate->exc_value;
                         ^
  pandas/_libs/lib.c:100432:20: error: ‘PyThreadState’ has no member named ‘exc_traceback’
       tmp_tb = tstate->exc_traceback;
                      ^
  pandas/_libs/lib.c:100433:11: error: ‘PyThreadState’ has no member named ‘exc_type’
       tstate->exc_type = local_type;
             ^
  pandas/_libs/lib.c:100434:11: error: ‘PyThreadState’ has no member named ‘exc_value’
       tstate->exc_value = local_value;
             ^
  pandas/_libs/lib.c:100435:11: error: ‘PyThreadState’ has no member named ‘exc_traceback’
       tstate->exc_traceback = local_tb;
             ^
  pandas/_libs/lib.c: In function ‘__Pyx__ExceptionSwap’:
  pandas/_libs/lib.c:101493:22: error: ‘PyThreadState’ has no member named ‘exc_type’
       tmp_type = tstate->exc_type;
                        ^
  pandas/_libs/lib.c:101494:23: error: ‘PyThreadState’ has no member named ‘exc_value’
       tmp_value = tstate->exc_value;
                         ^
  pandas/_libs/lib.c:101495:20: error: ‘PyThreadState’ has no member named ‘exc_traceback’
       tmp_tb = tstate->exc_traceback;
                      ^
  pandas/_libs/lib.c:101496:11: error: ‘PyThreadState’ has no member named ‘exc_type’
       tstate->exc_type = *type;
             ^
  pandas/_libs/lib.c:101497:11: error: ‘PyThreadState’ has no member named ‘exc_value’
       tstate->exc_value = *value;
             ^
  pandas/_libs/lib.c:101498:11: error: ‘PyThreadState’ has no member named ‘exc_traceback’
       tstate->exc_traceback = *tb;
             ^
  error: command 'gcc' failed with exit status 1
```