### PR TITLE
Require token to access the calendar

### DIFF
--- a/lowfat/admin.py
+++ b/lowfat/admin.py
@@ -145,8 +145,9 @@ class FundAdmin(SimpleHistoryAdmin):
                 'mandatory',
                 ]
             }),
-        ('GDPR', {
+        ('Publicity', {
             'fields': [
+                'can_be_included_in_calendar',
                 'can_be_advertise_before',
                 'can_be_advertise_after',
                 ]

--- a/lowfat/settings.py
+++ b/lowfat/settings.py
@@ -300,6 +300,10 @@ CONSTANCE_CONFIG = OrderedDict([
         3,
         "Month deadline that expenses must be submited.",
     )),
+    ("CALENDAR_ACCESS_TOKEN", (
+        "lKI7BSE7JCWaIw54xywVZy8zRTKLqOM3",
+        "Token to access the calendar.",
+    )),
 ])
 
 

--- a/lowfat/templates/lowfat/dashboard.html
+++ b/lowfat/templates/lowfat/dashboard.html
@@ -27,6 +27,7 @@
     <a class="btn btn-default btn-block" href="{% url 'blog' %}">Submit a blog post</a>
   </div>
 </div>
+<p><a href="{% url 'fund_ical' token=ical_token %}">Click here</a> to access the shared calendar of events related with fellows.</p>
 {% if user.is_superuser or user.is_staff %}
 <p><a href="{% url 'recent_actions' %}">Click here</a> to view last changes on the database.</p>
 <p><a href="{% url 'fund_import' %}">Click here</a> to import funding requests

--- a/lowfat/urls.py
+++ b/lowfat/urls.py
@@ -51,7 +51,7 @@ FUND_PATTERNS = [
     url(r'^(?P<fund_id>[0-9]+)/remove', views.fund_remove, name="fund_remove"),
     url(r'^(?P<fund_id>[0-9]+)/', views.fund_detail, name="fund_detail"),
     url(r'^previous/', views.fund_past, name="fund_past"),
-    url(r'^ical/', views.fund_ical, name="fund_ical"),
+    url(r'^ical/(?P<token>[0-9A-Za-z]{32})/', views.fund_ical, name="fund_ical"),
     url(r'^import/', views.fund_import, name="fund_import"),
     url(r'^', views.fund_form, name="fund"),
 ]

--- a/lowfat/views.py
+++ b/lowfat/views.py
@@ -13,6 +13,8 @@ from django.http import HttpResponse, HttpResponseRedirect, Http404
 from django.urls import reverse
 from django.shortcuts import render
 
+from constance import config
+
 import matplotlib
 matplotlib.use('AGG')
 from matplotlib.pyplot import bar, hist, savefig
@@ -480,7 +482,10 @@ def fund_past(request):
 
     return render(request, 'lowfat/fund_past.html', context)
 
-def fund_ical(request):
+def fund_ical(request, token):
+    if token != config.CALENDAR_ACCESS_TOKEN:
+        raise Http404("Expense claim does not exist.")
+
     funds = Fund.objects.filter(
         can_be_advertise_after=True,
     )

--- a/lowfat/views.py
+++ b/lowfat/views.py
@@ -53,7 +53,9 @@ def index(request):
 
 @login_required
 def dashboard(request):
-    context = {}
+    context = {
+        'ical_token': config.CALENDAR_ACCESS_TOKEN,
+    }
 
     if not request.user.is_superuser and not request.user.is_staff:
         try:


### PR DESCRIPTION
For security, the calendar requires a token to be visible. The token is shared among all the users.