### PR TITLE
Use geopy to provide latitute and longitude

### DIFF
--- a/lowfat/models.py
+++ b/lowfat/models.py
@@ -2,6 +2,8 @@ from datetime import datetime, date
 import re
 import hashlib
 
+from geopy.geocoders import Nominatim
+
 from constance import config
 
 import django.utils
@@ -616,6 +618,17 @@ class Fund(models.Model):
 
         if self.status == "A":
             self.approved = datetime.now()
+
+        geolocator = Nominatim()
+        try:
+            location = geolocator.geocode(
+                self.city,
+                country_bias=self.country
+            )
+            self.lon = location.longitude
+            self.lat = location.latitude
+        except:  # pylint: disable=bare-except
+            pass
 
         self.url = fix_url(self.url)
 

--- a/lowfat/views.py
+++ b/lowfat/views.py
@@ -15,6 +15,8 @@ from django.shortcuts import render
 
 from constance import config
 
+from geopy.geocoders import Nominatim
+
 from django_pandas.io import read_frame
 
 import matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ django-extensions
 django-pandas
 django-settings-export
 django-simple-history>=1.9.0
+geopy
 html2text
 markdown
 matplotlib


### PR DESCRIPTION
This is related with softwaresaved/lowfat#489.

geopy will query [OpenStreetMap](https://wiki.openstreetmap.org/wiki/Nominatim) for the latitude and longitude of the city that we provided in the form **every time that data is changed**. The information provided will be saved.

@marioa I want to have your feedback on this. Does this resolve softwaresaved/lowfat#489? Do the extra seconds to query OpenStreetMap worth?