### PR TITLE
Archive funding request if final expense is approved.

### DIFF
--- a/lowfat/forms.py
+++ b/lowfat/forms.py
@@ -660,6 +660,7 @@ class ExpenseReviewForm(GarlicForm):
         model = Expense
         fields = [
             'status',
+            'final',
             'asked_for_authorization_date',
             'send_to_finance_date',
             'amount_authorized_for_payment',
@@ -690,6 +691,7 @@ class ExpenseReviewForm(GarlicForm):
             Fieldset(
                 '',
                 'status',
+                'final',
                 'asked_for_authorization_date',
                 'send_to_finance_date',
                 PrependedText(

--- a/lowfat/views.py
+++ b/lowfat/views.py
@@ -636,6 +636,7 @@ def expense_review(request, expense_id):
 
         if formset.is_valid():
             expense = formset.save()
+            messages.success(request, 'Expense claim updated.')
             if not formset.cleaned_data["not_send_email_field"]:
                 expense_review_notification(
                     formset.cleaned_data['email'],
@@ -644,6 +645,12 @@ def expense_review(request, expense_id):
                     expense,
                     not formset.cleaned_data['not_copy_email_field']
                 )
+
+            if expense.status == 'A' and expense.final:
+                expense.fund.status = 'F'
+                expense.fund.save()
+                messages.success(request, 'Funding request archived.')
+            
             return HttpResponseRedirect(
                 reverse('expense_detail_relative', args=[expense.fund.id, expense.relative_number,])
             )


### PR DESCRIPTION
@gperu this implements what we agreed. If one expense is approved and it is the final one related to one funding request, the funding request will be archived.

Additionally, it provide some visual feedback to the user.

![screenshot from 2018-11-16 15-54-08](https://user-images.githubusercontent.com/1506457/48632309-81754280-e9b8-11e8-89d9-877695177fd8.png)

@gperu Could you review the text inside the green box? Thanks!