### PR TITLE
Add visual help for number of blog posts to expense claim

### DIFF
--- a/lowfat/templates/lowfat/expense_review.html
+++ b/lowfat/templates/lowfat/expense_review.html
@@ -17,64 +17,70 @@
 <div class="row">
   <div class="col-md-6">
     <h2>Fund</h2>
-<table class="table table-bordered">
-    <tbody>
+    <table class="table table-bordered">
+      <tbody>
         <tr>
-            <th>Requester name</th>
-            <td>
-              {{ expense.fund.claimant.fullname_link|safe }}
-              <a class="icon" href="mailto:{{ expense.fund.claimant.email }}">
-                <i class="fa fa-envelope" aria-hidden="true"></i>
-              </a>
-            </td>
+          <th>Requester name</th>
+          <td>
+            {{ expense.fund.claimant.fullname_link|safe }}
+            <a class="icon" href="mailto:{{ expense.fund.claimant.email }}">
+              <i class="fa fa-envelope" aria-hidden="true"></i>
+            </a>
+          </td>
         </tr>
         <tr>
-            <th>Funding request title</th>
-            <td>{{ expense.fund.title_link|safe }}</td>
+          <th>Funding request title</th>
+          <td>{{ expense.fund.title_link|safe }}</td>
         </tr>
         <tr>
-            <th>Budget approved</th>
-            <td>
-              {% if expense.fund.status in 'AF' %}
-              £{{ expense.fund.budget_approved }}
-              {% else %}
-              £0.00
-              {% endif %}
-            </td>
+          <th>Budget approved</th>
+          <td>
+            {% if expense.fund.status in 'AF' %}
+            £{{ expense.fund.budget_approved }}
+            {% else %}
+            £0.00
+            {% endif %}
+          </td>
         </tr>
         <tr>
-            <th>Extra sponsored</th>
-            <td>{{ expense.fund.extra_sponsored }}</td>
+          <th>Extra sponsored</th>
+          <td>{{ expense.fund.extra_sponsored }}</td>
         </tr>
         <tr>
-            <th>Recipient</th>
-            <td>
-              {% if expense.recipient_fullname %}
-              {{ expense.fund.extra_sponsored }}
-              {% else %}
-              {{ expense.fund.claimant.fullname }}
-              {% endif %}
-            </td>
+          <th>Recipient</th>
+          <td>
+            {% if expense.recipient_fullname %}
+            {{ expense.fund.extra_sponsored }}
+            {% else %}
+            {{ expense.fund.claimant.fullname }}
+            {% endif %}
+          </td>
         </tr>
         <tr>
-            <th>Final claim</th>
-            <td>{{ expense.final }}</td>
+          <th>Final claim</th>
+          <td>{{ expense.final }}</td>
         </tr>
         <tr>
           <th>Blog post (Submitted/Requested)</th>
           <td>{{ expense.fund.total_of_blog_posts }} / {{ expense.fund.required_blog_posts }}</td>
         </tr>
-    </tbody>
-</table>
-  {% include "lowfat/communication.html" %}
+      </tbody>
+    </table>
+    {% include "lowfat/communication.html" %}
   </div>
-  <div class="col-md-6">
-<h2>Expense</h2>
-<table class="table table-bordered">
-    <tbody>
+  <div class="col-md-6" style="background:
+       {% if expense.fund.total_of_blog_posts < expense.fund.required_blog_posts %}
+       #fcf8e3
+       {% else %}
+       #dff0d8
+       {% endif %}
+  ;" >
+    <h2>Expense</h2>
+    <table class="table table-bordered">
+      <tbody>
         <tr>
-            <th>Received date</th>
-            <td>{{ expense.added }}</td>
+          <th>Received date</th>
+          <td>{{ expense.added }}</td>
         </tr>
         {% if expense.advance_booking %}
         <tr>
@@ -82,9 +88,9 @@
           <td>{{ expense.advance_bookinge }}</td>
         </tr>
         {% endif %}
-    </tbody>
-</table>
-{% crispy formset %}
+      </tbody>
+    </table>
+    {% crispy formset %}
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
@gperu like we agreed. To add some background colour to the form.

# Screenshot

Without blog post

![screencapture-localhost-8000-request-1-expense-1-review-2018-11-16-16_09_17](https://user-images.githubusercontent.com/1506457/48633042-60155600-e9ba-11e8-836b-d6a7d558d4d8.png)

With blog post

![screencapture-localhost-8000-request-2-expense-1-review-2018-11-16-16_09_45](https://user-images.githubusercontent.com/1506457/48633056-699ebe00-e9ba-11e8-8b70-a81e56faeb97.png)
