### PR TITLE
Fix email error 500

### DIFF
--- a/lowfat/mail.py
+++ b/lowfat/mail.py
@@ -185,7 +185,7 @@ def review_notification(request, email_url, user_email, context, mail, copy_to_s
 
         try:
             msg.send(fail_silently=False)
-        
+
         except (ConnectionRefusedError, smtplib.SMTPRecipientsRefused) as exc:
             messages.error(request, "Failed to send notification email.")
             logger.error(exc)
@@ -193,7 +193,6 @@ def review_notification(request, email_url, user_email, context, mail, copy_to_s
         finally:
             # Every email is archived in the database
             mail.save()
-
 
 
 def fund_review_notification(request, message, sender, old, new, copy_to_staffs):

--- a/lowfat/mail.py
+++ b/lowfat/mail.py
@@ -9,6 +9,7 @@ from constance import config
 
 from html2text import html2text
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.flatpages.models import FlatPage
 from django.contrib.sites.models import Site
@@ -174,9 +175,11 @@ def review_notification(request, email_url, user_email, context, mail, copy_to_s
             flatemail.title,
             plain_text,
             mail.sender.email,
+            settings.DEFAULT_FROM_EMAIL,
             user_email,
             cc=cc_addresses,
-            bcc=ast.literal_eval(config.STAFFS_EMAIL) if copy_to_staffs else None
+            bcc=ast.literal_eval(config.STAFFS_EMAIL) if copy_to_staffs else None,
+            reply_to=config.FELLOWS_MANAGEMENT_EMAIL
         )
         msg.attach_alternative(html, "text/html")
 

--- a/lowfat/mail.py
+++ b/lowfat/mail.py
@@ -2,11 +2,14 @@
 Send email for some views.
 """
 import ast
+import smtplib
+import logging
 
 from constance import config
 
 from html2text import html2text
 
+from django.contrib import messages
 from django.contrib.flatpages.models import FlatPage
 from django.contrib.sites.models import Site
 from django.core.mail import EmailMultiAlternatives
@@ -14,6 +17,9 @@ from django.template import Context, Template
 
 from . import models
 from .settings import DEFAULT_FROM_EMAIL, SITE_ID
+
+
+logger = logging.getLogger(__name__)
 
 
 def html2text_fix(html):
@@ -142,7 +148,7 @@ def new_blog_notification(blog):
     new_notification(staff_url, email_url, user_email, context, mail)
 
 
-def review_notification(email_url, user_email, context, mail, copy_to_staffs=False, copy_to_gatekeeper=False):   # pylint: disable=too-many-arguments
+def review_notification(request, email_url, user_email, context, mail, copy_to_staffs=False, copy_to_gatekeeper=False):   # pylint: disable=too-many-arguments
     """Compose the message and send the email."""
     if config.CLAIMANT_EMAIL_NOTIFICATION and email_url is not None:
         # Generate message
@@ -173,12 +179,21 @@ def review_notification(email_url, user_email, context, mail, copy_to_staffs=Fal
             bcc=ast.literal_eval(config.STAFFS_EMAIL) if copy_to_staffs else None
         )
         msg.attach_alternative(html, "text/html")
-        msg.send(fail_silently=False)
-        # Every email is archived in the database
-        mail.save()
+
+        try:
+            msg.send(fail_silently=False)
+        
+        except (ConnectionRefusedError, smtplib.SMTPRecipientsRefused) as exc:
+            messages.error(request, "Failed to send notification email.")
+            logger.error(exc)
+
+        finally:
+            # Every email is archived in the database
+            mail.save()
 
 
-def fund_review_notification(message, sender, old, new, copy_to_staffs):
+
+def fund_review_notification(request, message, sender, old, new, copy_to_staffs):
     user_email = [new.claimant.email]
     context = {
         "old": old,
@@ -200,10 +215,10 @@ def fund_review_notification(message, sender, old, new, copy_to_staffs):
     else:
         email_url = None
 
-    review_notification(email_url, user_email, context, mail, copy_to_staffs)
+    review_notification(request, email_url, user_email, context, mail, copy_to_staffs)
 
 
-def expense_review_notification(message, sender, old, new, copy_to_staffs):
+def expense_review_notification(request, message, sender, old, new, copy_to_staffs):
     user_email = [new.fund.claimant.email]
 
     context = {
@@ -226,10 +241,10 @@ def expense_review_notification(message, sender, old, new, copy_to_staffs):
     else:
         email_url = None
 
-    review_notification(email_url, user_email, context, mail, copy_to_staffs)
+    review_notification(request, email_url, user_email, context, mail, copy_to_staffs)
 
 
-def blog_review_notification(message, sender, old, new, copy_to_staffs):
+def blog_review_notification(request, message, sender, old, new, copy_to_staffs):
     user_email = [new.author.email]
     if new.coauthor.all():
         user_email.extend([author.email for author in new.coauthor.all()])
@@ -261,7 +276,7 @@ def blog_review_notification(message, sender, old, new, copy_to_staffs):
         email_url = None
         copy_to_gatekeeper = False
 
-    review_notification(email_url, user_email, context, mail, copy_to_staffs, copy_to_gatekeeper)
+    review_notification(request, email_url, user_email, context, mail, copy_to_staffs, copy_to_gatekeeper)
 
 
 def staff_reminder(request):  # pylint: disable=invalid-name

--- a/lowfat/views/blog.py
+++ b/lowfat/views/blog.py
@@ -223,6 +223,7 @@ def blog_review(request, blog_id):
             messages.success(request, 'Blog updated.')
             if not formset.cleaned_data["not_send_email_field"]:
                 blog_review_notification(
+                    request,
                     formset.cleaned_data['email'],
                     request.user,
                     old_blog,

--- a/lowfat/views/expense.py
+++ b/lowfat/views/expense.py
@@ -214,6 +214,7 @@ def expense_review(request, expense_id):
             messages.success(request, 'Expense claim updated.')
             if not formset.cleaned_data["not_send_email_field"]:
                 expense_review_notification(
+                    request,
                     formset.cleaned_data['email'],
                     request.user,
                     old_expense,

--- a/lowfat/views/fund.py
+++ b/lowfat/views/fund.py
@@ -104,6 +104,7 @@ def fund_form(request, **kargs):  # pylint: disable=too-many-branches,too-many-s
                 messages.success(request, 'Funding request approved.')
                 if not formset.cleaned_data["not_send_email_field"]:
                     fund_review_notification(
+                        request,
                         "",
                         request.user,
                         fund,
@@ -277,6 +278,7 @@ def fund_review(request, fund_id):
                 messages.success(request, 'Funding request updated.')
             if not formset.cleaned_data["not_send_email_field"]:
                 fund_review_notification(
+                    request,
                     formset.cleaned_data['email'],
                     request.user,
                     old_fund,


### PR DESCRIPTION
See #635 

The reason for the error 500s when sending review notifications seems to be that the emails were sent using the user who initiated the action as the mail sending address - this is not always someone who is on Edinburgh's mail servers! This PR changes the sending address to `no-reply@software.ac.uk` with a reply-to set to the fellows management email.