### PR TITLE
583 edit email notification claimant profile updated actions required

### DIFF
--- a/lowfat/fixtures/flatpages.json
+++ b/lowfat/fixtures/flatpages.json
@@ -305,7 +305,7 @@
     "fields": {
         "url": "/email/template/claimant/staff/update/",
         "title": "Claimant Profile Updated - Actions required",
-        "content": "<!DOCTYPE HTML>\r\n<html>\r\n<head>\r\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\r\n</head>\r\n<body>\r\n<p>Hi,</p>\r\n<p><strong>On {{ claimant.updated }}</strong>, <a href=\"{{ protocol }}://{{ site.domain }}{{ claimant.link }}\">{{ claimant.fullname }}</a>'s profile was updated. The following actions are required:</p>\r\n<ul>\r\n<li>update profile on Institute's website</li>\r\n<li>update email address on mailing list</li>\r\n</ul>\r\n<p>\r\n---<br>\r\nLowFAT\r\n</p>\r\n</body>\r\n</html>",
+        "content": "<!DOCTYPE HTML>\r\n<html>\r\n<head>\r\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\r\n</head>\r\n<body>\r\n<p>Hi,</p>\r\n<p><strong>On {{ claimant.email }}</strong>, <a href=\"{{ protocol }}://{{ site.domain }}{{ claimant.link }}\">{{ claimant.fullname }}</a>'s profile was updated. The following actions are required:</p>\r\n<ul>\r\n<li>update profile on Institute's website</li>\r\n<li>update email address on mailing list</li>\r\n</ul>\r\n<p>Old email: old email address </p>\r\n<p>New email: {{ claimant.email }}\r\n</p><p>\r\n---<br>\r\nLowFAT\r\n</p>\r\n</body>\r\n</html>",
         "enable_comments": false,
         "template_name": "",
         "registration_required": false,

--- a/lowfat/fixtures/flatpages.json
+++ b/lowfat/fixtures/flatpages.json
@@ -305,7 +305,7 @@
     "fields": {
         "url": "/email/template/claimant/staff/update/",
         "title": "Claimant Profile Updated - Actions required",
-        "content": "<!DOCTYPE HTML>\r\n<html>\r\n<head>\r\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\r\n</head>\r\n<body>\r\n<p>Hi,</p>\r\n<p><strong>On {{ claimant.email }}</strong>, <a href=\"{{ protocol }}://{{ site.domain }}{{ claimant.link }}\">{{ claimant.fullname }}</a>'s profile was updated. The following actions are required:</p>\r\n<ul>\r\n<li>update profile on Institute's website</li>\r\n<li>update email address on mailing list</li>\r\n</ul>\r\n<p>Old email: old email address </p>\r\n<p>New email: {{ claimant.email }}\r\n</p><p>\r\n---<br>\r\nLowFAT\r\n</p>\r\n</body>\r\n</html>",
+        "content": "<!DOCTYPE HTML>\r\n<html>\r\n<head>\r\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\r\n</head>\r\n<body>\r\n<p>Hi,</p>\r\n<p><strong>On {{ claimant.email }}</strong>, <a href=\"{{ protocol }}://{{ site.domain }}{{ claimant.link }}\">{{ claimant.fullname }}</a>'s profile was updated. The following actions are required:</p>\r\n<ul>\r\n<li>update profile on Institute's website</li>\r\n<li>update email address on mailing list</li>\r\n</ul>\r\n<p>Old email: {{ previous_email }} </p>\r\n<p>New email: {{ claimant.email }}\r\n</p><p>\r\n---<br>\r\nLowFAT\r\n</p>\r\n</body>\r\n</html>",
         "enable_comments": false,
         "template_name": "",
         "registration_required": false,

--- a/lowfat/mail.py
+++ b/lowfat/mail.py
@@ -334,14 +334,13 @@ def staff_follow_up(requests):  # pylint: disable=invalid-name
 def claimant_profile_update_notification(claimant):  # pylint: disable=invalid-name
     if config.STAFF_EMAIL_REMINDER:
         staff_url = "/email/template/claimant/staff/update/"
-
+        # need to access the third element of the history because each claimant change is saved twice in
+        # claimant_form() once in 'claimant = formset.save()' and once in 'claimant.update_latlon()'
         context = {
             "claimant": claimant,
             "protocol": "https",
             "site": Site.objects.get(id=SITE_ID),
             "FELLOWS_MANAGEMENT_EMAIL": config.FELLOWS_MANAGEMENT_EMAIL,
-            # need to access the third element of the history because each claimant change is saved twice in
-            # claimant_form() once in 'claimant = formset.save()' and once in 'claimant.update_latlon()'
             "previous_email": claimant.history.all()[2].email
         }
 

--- a/lowfat/mail.py
+++ b/lowfat/mail.py
@@ -340,9 +340,8 @@ def claimant_profile_update_notification(claimant):  # pylint: disable=invalid-n
             "protocol": "https",
             "site": Site.objects.get(id=SITE_ID),
             "FELLOWS_MANAGEMENT_EMAIL": config.FELLOWS_MANAGEMENT_EMAIL,
-            
-            #need to access the third element of the history because each claimant change is saved twice in claimant_form()
-            #once in 'claimant = formset.save()' and once in 'claimant.update_latlon()'
+            # need to access the third element of the history because each claimant change is saved twice in
+            # claimant_form() once in 'claimant = formset.save()' and once in 'claimant.update_latlon()'
             "previous_email": claimant.history.all()[2].email
         }
 

--- a/lowfat/mail.py
+++ b/lowfat/mail.py
@@ -340,6 +340,10 @@ def claimant_profile_update_notification(claimant):  # pylint: disable=invalid-n
             "protocol": "https",
             "site": Site.objects.get(id=SITE_ID),
             "FELLOWS_MANAGEMENT_EMAIL": config.FELLOWS_MANAGEMENT_EMAIL,
+            
+            #need to access the third element of the history because each claimant change is saved twice in claimant_form()
+            #once in 'claimant = formset.save()' and once in 'claimant.update_latlon()'
+            "previous_email": claimant.history.all()[2].email
         }
 
         flatemail = FlatPage.objects.get(url=staff_url)

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,4 @@ max-line-length = 120
 ignore =
     E501  ; line too long
     W503  ; line break before binary operator
-    ; F401  ; imported but unused
-    ; F403  ; star import used
-    ; F405  ; may be undefined or in star imports
     E722  ; do not use bare except

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,9 @@ commands =
 exclude =
     migrations
 max-line-length = 120
-ignore =
-    E501  ; line too long
-    W503  ; line break before binary operator
-    E722  ; do not use bare except
+ignore = E501, W503, E722
+
+# Errors Ignored
+# E501  ; line too long
+# W503  ; line break before binary operator
+# E722  ; do not use bare except


### PR DESCRIPTION
Accessed old email address through HistoricalRecords() from django-simple-history and saved this in the context dictionary of the claimant_profile_update_notification() function in mail.py.  Previous email is the third element of the history as each change saves twice, once in 'claimant = formset.save()' and once in 'claimant.update_latlon()', this is explained in the comments on the claimant_profile_update_notification() function in mail.py.  Edited email text in flatpages.json to include old and updated email addresses.