### PR TITLE
Fulfilled issue #631

### DIFF
--- a/lowfat/templates/lowfat/fund_detail.html
+++ b/lowfat/templates/lowfat/fund_detail.html
@@ -96,7 +96,6 @@
       </td>
     </tr>
     {% endif %}
-    {% if user.is_staff or user == fund.claimant %}
     <tr>
       <th>Justification</th>
       <td>{{ fund.justification | markdown | safe }}</td>
@@ -113,7 +112,6 @@
       <th>Additional information</th>
       <td>{{ fund.additional_info | markdown | safe }}</td>
     </tr>
-    {% endif %}
   </tbody>
 </table>
 <h2>Budget Summary</h2>

--- a/lowfat/templates/lowfat/fund_review.html
+++ b/lowfat/templates/lowfat/fund_review.html
@@ -51,7 +51,7 @@
             <td>{{ fund.end_date }}</td>
         </tr>
         <tr>
-          <th>Justication</th>
+          <th>Justification</th>
           <td>{{ fund.justification | markdown | safe }}</td>
         </tr>
         <tr>


### PR DESCRIPTION
Fixed typo.  Edited fund_detail.html to allow a claimant to see the justification, success, and additional information related to their funding request.  Authentication to ensure claimants can only see their own funding request occurs in the fund_detail view so it was not necessary to add this into the fund_detail.html template.