### PR TITLE
Amount committed calculation edited

### DIFF
--- a/lowfat/models/claimant.py
+++ b/lowfat/models/claimant.py
@@ -439,9 +439,11 @@ class Claimant(models.Model):
             grant_heading="F"
         )
 
+        # Minus sum of amount approved not amount claimed
+        
         spent_from_committed = 0
         for fund in this_claimant_funds:
-            spent_from_committed += sum([expense.amount_claimed for expense in Expense.objects.filter(
+            spent_from_committed += sum([expense.fund.budget_approved for expense in Expense.objects.filter(
                 fund=fund,
                 status__in=['A', 'M', 'F']
             )])


### PR DESCRIPTION
When the expense claim is approved, the budget for the associated funding request (rather than the amount of the expense claim, as it was previously) is subtracted from the amount committed total.  This means that the amount committed reflects the actual amount for funding requests that have been approved but for which expenses have not yet been claimed.